### PR TITLE
Use displayName to get initials of author.

### DIFF
--- a/src/main/resources/js/commitgraph.js
+++ b/src/main/resources/js/commitgraph.js
@@ -248,7 +248,7 @@
     };
 
     CommitVM.prototype.getAuthorInitials = function() {
-        var tokens = this.author.name.split(' ');
+        var tokens = this.author.displayName.split(' ');
         var initials = tokens.map(function(token) {
             return token[0].toUpperCase();
         }).join('');


### PR DESCRIPTION
Used this for my own instance (both developers usernames started with same initial) to fix #30 
