### PR TITLE
Added repository settings page: gravatar, links from text, links from is...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,12 @@
             <version>1.1.1</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.atlassian.activeobjects</groupId>
+            <artifactId>activeobjects-plugin</artifactId>
+            <version>0.21.2</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/com/plugin/commitgraph/admin/RepositorySettings.java
+++ b/src/main/java/com/plugin/commitgraph/admin/RepositorySettings.java
@@ -1,0 +1,57 @@
+/**
+ * Repository settings for stash codesearch.
+ */
+
+package com.plugin.commitgraph.admin;
+
+import net.java.ao.Entity;
+import net.java.ao.Preload;
+import net.java.ao.schema.Default;
+import net.java.ao.schema.NotNull;
+import net.java.ao.schema.Table;
+import net.java.ao.schema.Unique;
+
+@Table("CGNRepoSettings")
+@Preload
+public interface RepositorySettings extends Entity {
+
+    @NotNull
+    @Unique
+    public String getRepositoryId ();
+    public void setRepositoryId (String value);
+
+    // Regex for issue id
+    public static final boolean USE_REGEX_DEFAULT = false;
+    @NotNull
+    @Default(USE_REGEX_DEFAULT + "")
+    public boolean getUseRegex();
+    public void setUseRegex(boolean value);
+
+    // Regex for issue id
+    public static final String REF_REGEX_DEFAULT = "\\\\B#(\\\\d+)";
+    @NotNull
+    @Default(REF_REGEX_DEFAULT)
+    public String getRefRegex();
+    public void setRefRegex(String value);
+
+    // Regex replace for issue id
+    public static final String REF_REGEX_REPLACE_DEFAULT = "http://some.website/issue/$1";
+    @NotNull
+    @Default(REF_REGEX_REPLACE_DEFAULT)
+    public String getRefRegexReplace();
+    public void setRefRegexReplace(String value);
+
+    // Use Gravatar service
+    public static final boolean USE_GRAVATAR_DEFAULT = false;
+    @NotNull
+    @Default(USE_GRAVATAR_DEFAULT + "")
+    public boolean getUseGravatar();
+    public void setUseGravatar(boolean value);
+
+    // Create links in commit messages
+    public static final boolean CREATE_LINKS_DEFAULT = false;
+    @NotNull
+    @Default(CREATE_LINKS_DEFAULT + "")
+    public boolean getCreateLinks();
+    public void setCreateLinks(boolean value);
+}

--- a/src/main/java/com/plugin/commitgraph/admin/RepositorySettingsServlet.java
+++ b/src/main/java/com/plugin/commitgraph/admin/RepositorySettingsServlet.java
@@ -1,0 +1,196 @@
+package com.plugin.commitgraph.admin;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import com.atlassian.soy.renderer.SoyTemplateRenderer;
+import com.atlassian.stash.exception.AuthorisationException;
+import com.atlassian.stash.repository.Repository;
+import com.atlassian.stash.repository.RepositoryService;
+import com.atlassian.stash.server.ApplicationPropertiesService;
+import com.atlassian.stash.user.Permission;
+import com.atlassian.stash.user.PermissionValidationService;
+import com.atlassian.stash.user.SecurityService;
+import com.google.common.collect.ImmutableMap;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.regex.Pattern;
+
+public class RepositorySettingsServlet extends HttpServlet {
+
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger log = LoggerFactory.getLogger(RepositorySettingsServlet.class);
+
+    private final ApplicationPropertiesService propertiesService;
+
+    private final SettingsManager settingsManager;
+
+    private final PermissionValidationService validationService;
+
+    private final RepositoryService repositoryService;
+
+    private final SecurityService securityService;
+
+    private final SoyTemplateRenderer soyTemplateRenderer;
+
+    public RepositorySettingsServlet(
+        ApplicationPropertiesService propertiesService,
+        SettingsManager settingsManager,
+        PermissionValidationService validationService,
+        RepositoryService repositoryService,
+        SecurityService securityService,
+        SoyTemplateRenderer soyTemplateRenderer) {
+        this.propertiesService = propertiesService;
+        this.settingsManager = settingsManager;
+        this.validationService = validationService;
+        this.repositoryService = repositoryService;
+        this.securityService = securityService;
+        this.soyTemplateRenderer = soyTemplateRenderer;
+    }
+
+    // Make sure the current user is authenticated
+    private boolean verifyLoggedIn(HttpServletRequest req, HttpServletResponse resp)
+        throws IOException {
+        try {
+            validationService.validateAuthenticated();
+        } catch (AuthorisationException notLoggedInException) {
+            try {
+                resp.sendRedirect(propertiesService.getLoginUri(URI.create(req.getRequestURL() +
+                    (req.getQueryString() == null ? "" : "?" + req.getQueryString())
+                    )).toASCIIString());
+            } catch (Exception e) {
+                log.error("Unable to redirect unauthenticated user to login page", e);
+            }
+            return false;
+        }
+        return true;
+    }
+
+    // Make sure the current user is a repo admin
+    private boolean verifyRepoAdmin(HttpServletRequest req, HttpServletResponse resp,
+        Repository repository) throws IOException {
+        try {
+            validationService.validateForRepository(repository, Permission.REPO_ADMIN);
+        } catch (AuthorisationException notRepoAdminException) {
+            resp.sendError(HttpServletResponse.SC_UNAUTHORIZED, "You do not have permission to access this page.");
+            return false;
+        }
+        return true;
+    }
+
+    private void renderPage(HttpServletRequest req, HttpServletResponse resp,
+        Repository repository, RepositorySettings repositorySettings,
+        Collection<? extends Object> errors) throws ServletException, IOException {
+        resp.setContentType("text/html");
+        try {
+            ImmutableMap<String, Object> data = new ImmutableMap.Builder<String, Object>()
+                .put("repository", repository)
+                .put("settings", repositorySettings)
+                .put("errors", errors)
+                .build();
+            soyTemplateRenderer.render(resp.getWriter(),
+                "com.plugin.commitgraph.commitgraph:network-soy",
+                "plugin.commitgraph.repositorySettingsPage",
+                data);
+        } catch (Exception e) {
+            log.error("Error rendering Soy template", e);
+        }
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+        throws ServletException, IOException {
+        if (!verifyLoggedIn(req, resp)) {
+            return;
+        }
+        Repository repository = getRepository(req);
+        if (repository == null) {
+            resp.sendError(HttpServletResponse.SC_NOT_FOUND, "Repo not found.");
+            return;
+        }
+        if (verifyRepoAdmin(req, resp, repository)) {
+            renderPage(req, resp, repository, settingsManager.getRepositorySettings(repository),
+                Collections.emptyList());
+        }
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp)
+        throws ServletException, IOException {
+        if (!verifyLoggedIn(req, resp)) {
+            return;
+        }
+        final Repository repository = getRepository(req);
+        if (repository == null) {
+            resp.sendError(HttpServletResponse.SC_NOT_FOUND, "Repo not found.");
+            return;
+        }
+        if (!verifyRepoAdmin(req, resp, repository)) {
+            return;
+        }
+
+        RepositorySettings s = settingsManager.getRepositorySettings(repository);
+
+        // Parse arguments
+        ArrayList<String> errors = new ArrayList<String>();
+
+        boolean useRegex = "on".equals(req.getParameter("useRegex"));
+        boolean useGravatar = "on".equals(req.getParameter("useGravatar"));
+        boolean createLinks = "on".equals(req.getParameter("createLinks"));
+
+        String refRegex = req.getParameter("refRegex");
+
+        if(refRegex == null)
+            refRegex = s.getRefRegex();
+
+        try {
+            Pattern.compile(refRegex);
+        } catch (Exception e) {
+            errors.add("Invalid regex: \"" + refRegex + "\"");
+        }
+
+        String refRegexReplace = req.getParameter("refRegexReplace");
+
+        if(refRegexReplace == null)
+            refRegexReplace = s.getRefRegexReplace();
+
+        if (refRegexReplace.isEmpty()) {
+           errors.add("Regex replace text can not be empty");
+        }
+
+        // Update settings object iff no parse errors
+        RepositorySettings settings;
+        if (errors.isEmpty()) {
+            settings = settingsManager.setRepositorySettings(repository, useRegex, refRegex, refRegexReplace,
+                    useGravatar, createLinks);
+        } else {
+            settings = settingsManager.getRepositorySettings(repository);
+        }
+
+        renderPage(req, resp, repository, settings, errors);
+    }
+
+    private Repository getRepository(HttpServletRequest req) {
+        String uri = req.getRequestURI();
+        String[] uriParts = uri.split("/");
+        if (uriParts.length < 2) {
+            return null;
+        }
+        return repositoryService.getBySlug(
+            uriParts[uriParts.length - 2], uriParts[uriParts.length - 1]);
+    }
+
+}

--- a/src/main/java/com/plugin/commitgraph/admin/SettingsManager.java
+++ b/src/main/java/com/plugin/commitgraph/admin/SettingsManager.java
@@ -1,0 +1,18 @@
+/**
+ * Stores and retrieves codesearch global settings.
+ */
+
+package com.plugin.commitgraph.admin;
+import com.atlassian.stash.repository.Repository;
+
+public interface SettingsManager {
+    RepositorySettings getRepositorySettings (Repository repository);
+
+    RepositorySettings setRepositorySettings (
+        Repository repository,
+        boolean useRegex,
+        String refRegex,
+        String refRegexReplace,
+        boolean useGravatar,
+        boolean createLinks);
+}

--- a/src/main/java/com/plugin/commitgraph/admin/SettingsManagerImpl.java
+++ b/src/main/java/com/plugin/commitgraph/admin/SettingsManagerImpl.java
@@ -1,0 +1,72 @@
+/**
+ * Default implementation of SettingsManager.
+ */
+
+package com.plugin.commitgraph.admin;
+
+import com.atlassian.activeobjects.external.ActiveObjects;
+import com.atlassian.stash.repository.Repository;
+import net.java.ao.DBParam;
+import net.java.ao.Query;
+
+public class SettingsManagerImpl implements SettingsManager {
+
+    private final ActiveObjects ao;
+
+    public SettingsManagerImpl (ActiveObjects ao) {
+        this.ao = ao;
+    }
+
+    @Override
+    public RepositorySettings getRepositorySettings (Repository repository) {
+        String repoId = repository.getProject().getKey() + "^" + repository.getSlug();
+        RepositorySettings [] settings;
+        synchronized (ao) {
+            settings = ao.find(RepositorySettings.class,
+                Query.select().where("REPOSITORY_ID = ?", repoId));
+        }
+        if (settings.length > 0) {
+            return settings[0];
+        }
+        synchronized (ao) {
+            return ao.create(RepositorySettings.class, new DBParam("REPOSITORY_ID", repoId));
+        }
+    }
+
+    @Override
+    public RepositorySettings setRepositorySettings (
+            Repository repository,
+            boolean useRegex,
+            String refRegex,
+            String refRegexReplace,
+            boolean useGravatar,
+            boolean createLinks) {
+        String repoId = repository.getProject().getKey() + "^" + repository.getSlug();
+        RepositorySettings[] settings;
+        synchronized (ao) {
+            settings = ao.find(RepositorySettings.class,
+                Query.select().where("REPOSITORY_ID = ?", repoId));
+        }
+        if (settings.length > 0) {
+            settings[0].setUseRegex(useRegex);
+            settings[0].setRefRegex(refRegex);
+            settings[0].setRefRegexReplace(refRegexReplace);
+            settings[0].setUseGravatar(useGravatar);
+            settings[0].setCreateLinks(createLinks);
+            settings[0].save();
+            return settings[0];
+        }
+        synchronized (ao) {
+            return ao.create(
+                RepositorySettings.class,
+                new DBParam("REPOSITORY_ID", repoId),
+                new DBParam("USE_REGEX", useRegex),
+                new DBParam("REF_REGEX", refRegex),
+                new DBParam("REF_REGEX_REPLACE", refRegexReplace),
+                new DBParam("USE_GRAVATAR", useGravatar),
+                new DBParam("CREATE_LINKS", createLinks)
+            );
+        }
+    }
+
+}

--- a/src/main/java/networkservlet/NetworkServlet.java
+++ b/src/main/java/networkservlet/NetworkServlet.java
@@ -1,5 +1,6 @@
 package networkservlet;
 
+import com.plugin.commitgraph.admin.SettingsManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,14 +22,19 @@ import com.atlassian.plugin.webresource.WebResourceManager;
 public class NetworkServlet extends HttpServlet {
     private static final Logger log = LoggerFactory.getLogger(NetworkServlet.class);
 
+    private final SettingsManager settingsManager;
     private final RepositoryService repositoryService;
     private final SoyTemplateRenderer soyTemplateRenderer;
     private final WebResourceManager webResourceManager;
 
-    public NetworkServlet(SoyTemplateRenderer soyTemplateRenderer, RepositoryService repositoryService, WebResourceManager webResourceManager) {
+    public NetworkServlet(SoyTemplateRenderer soyTemplateRenderer,
+                          RepositoryService repositoryService,
+                          WebResourceManager webResourceManager,
+                          SettingsManager settingsManager) {
         this.soyTemplateRenderer = soyTemplateRenderer;
         this.repositoryService = repositoryService;
         this.webResourceManager = webResourceManager;
+        this.settingsManager = settingsManager;
     }
 
     protected void render(HttpServletResponse resp, String templateName, Map<String, Object> data) throws IOException, ServletException {
@@ -67,6 +73,9 @@ public class NetworkServlet extends HttpServlet {
         }
 
         webResourceManager.requireResource("com.plugin.commitgraph.commitgraph:commitgraph-resources");
-        render(resp, "plugin.network.network", ImmutableMap.<String, Object>of("repository", repository));
+        render(resp, "plugin.network.network", ImmutableMap.<String, Object>of (
+                "repository", repository,
+                "settings", settingsManager.getRepositorySettings(repository)
+        ));
     }
 }

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -31,6 +31,8 @@
     <resource type="download" name="jquery.commits-graph.js" location="/js/jquery.commits-graph.js"/>
     <resource type="download" name="commitgraph.js" location="/js/commitgraph.js"/>
     <resource type="download" name="images/" location="/images"/>
+    <resource location="/js/lib/jquery.linkify.js" name="jquery.linkify.js" type="download"/>
+    <resource location="/js/lib/jquery.md5.js" name="jquery.md5.js" type="download"/>
     <context>commitgraph</context>
   </web-resource>
 
@@ -39,6 +41,9 @@
     <interface>com.plugin.commitgraph.MyPluginComponent</interface>
   </component>
 
+  <component class="com.plugin.commitgraph.admin.SettingsManagerImpl" key="settings-manager" public="true">
+    <interface>com.plugin.commitgraph.admin.SettingsManager</interface>
+  </component>
   <!-- import from the product container -->
   <component-import key="applicationProperties" interface="com.atlassian.sal.api.ApplicationProperties"/>
   <component-import key="soyTemplateRenderer" interface="com.atlassian.soy.renderer.SoyTemplateRenderer"/>
@@ -47,20 +52,37 @@
   <component-import key="repositoryService" interface="com.atlassian.stash.repository.RepositoryService"/>
   <component-import key="webResourceManager" interface="com.atlassian.plugin.webresource.WebResourceManager"/>
 
+  <component-import interface="com.atlassian.activeobjects.external.ActiveObjects" key="activeObjects"/>
 
   <servlet name="Network Servlet" i18n-name-key="network-servlet.name" key="networkservlet" class="networkservlet.NetworkServlet">
     <description key="network-servlet.description">The Network Servlet Plugin</description>
     <url-pattern>/network/*</url-pattern>
   </servlet>
 
+  <servlet class="com.plugin.commitgraph.admin.RepositorySettingsServlet" key="repository-settings-servlet">
+    <description key="repository-settings-servlet.description">The Network Plugin Repository Settings</description>
+    <url-pattern>/networkrepositorysettings/*</url-pattern>
+  </servlet>
   <web-item key="network-plugin-tab" name="Repository navigation tab" section="stash.repository.nav" weight="30">
     <label>Network</label>
     <condition class="com.atlassian.stash.web.conditions.RepositoryNotEmptyCondition"/>
     <link>/plugins/servlet/network/${repository.project.key}/${repository.slug}</link>
     <param name="stashIconClass">aui-icon icon-commit-graph</param>
   </web-item>
+  <web-item key="repository-settings-link" name="Network plugin" section="stash.repository.settings.panel" weight="20">
+    <label>Network plugin</label>
+    <link linkId="scs-repository-settings-link">/plugins/servlet/networkrepositorysettings/${repository.project.key}/${repository.slug}
+        </link>
+    <tooltip>Repository configuration options for Stash Network plugin</tooltip>
+  </web-item>
+
+  <ao key="ao-module">
+    <description>Stash Commitgraph settings DB</description>
+    <entity>com.plugin.commitgraph.admin.RepositorySettings</entity>
+  </ao>
 
   <stash-resource key="network-soy" name="Network Soy Templates">
     <directory location="/templates/"/>
+    <dependency>com.atlassian.stash.stash-web-plugin:global</dependency>
   </stash-resource>
 </atlassian-plugin>

--- a/src/main/resources/commitgraph.properties
+++ b/src/main/resources/commitgraph.properties
@@ -2,3 +2,5 @@
 my.plugin.name=network
 network-servlet.name=network
 network-servlet.description=The Network Servlet Plugin
+repository-settings-servlet.name=Repository Settings Servlet
+repository-settings-servlet.description=The Repository Settings Servlet Plugin

--- a/src/main/resources/css/commitgraph.css
+++ b/src/main/resources/css/commitgraph.css
@@ -16,12 +16,12 @@
 
 #commit-graph-table {
     font-size: 12px;
-    table-layout: fixed;
+    line-height: 1;
 }
 
 #commit-graph-table td, #commit-graph-table th {
     white-space: nowrap;
-    padding: 6px 10px !important;
+    padding: 3px 7px !important;
 }
 
 #commit-graph {
@@ -30,7 +30,7 @@
     left: 0;
     max-width: 50%;
     overflow: hidden;
-    padding-top: 30px;
+    padding-top: 19px;
 }
 
 .commit-container {
@@ -79,4 +79,33 @@
 
 .commits-table .changesetid + .merge-lozenge {
     margin-left: 5px;
+}
+
+.commits-table td.author {
+	text-align: center !important;
+}
+.commits-table td.author .user-avatar {
+	margin-right: 0;
+}
+
+.commits-table .message {
+	max-width: 250px;
+}
+
+.commits-table .message > span {
+	-o-text-overflow: ellipsis;
+	text-overflow: ellipsis;
+	overflow: hidden;
+	white-space: nowrap;
+	display: inline-block;
+	width: 100%;
+	vertical-align: middle;
+}
+
+.commits-table td.author, .commits-table .changeset, .commits-table .commit-date {
+	width: 1%;
+}
+
+.commits-table td.changeset, .commits-table td.message, .commits-table td.commit-date {
+	vertical-align: middle;
 }

--- a/src/main/resources/js/commitgraph.js
+++ b/src/main/resources/js/commitgraph.js
@@ -236,6 +236,21 @@
                 if (box.width > width)
                     self.els.$graphBox.css('overflow-x', 'scroll');
                 $('.commit-container').css('padding-left', width);
+
+                // Create link from issues id
+                if (CommitGraph.useRegex) {
+                    console.log("a");
+                    var re = new RegExp(CommitGraph.refRegex, 'g');
+
+                    $(".commits-table .message").each(function () {
+                        jQuery(this).html(jQuery(this).text().replace(re, "<a href=\"" + CommitGraph.refRegexReplace + "\" target=\"_blank\">$&</a>"));
+                    });
+                }
+
+                // Create link from "http://..." text
+                if (CommitGraph.createLinks) {
+                    $(".commits-table .message").linkify();
+                }
             }
         });
     };
@@ -245,6 +260,13 @@
         this.isMerge = this.parents.length > 1;
         this.date = new Date(this.authorTimestamp);
         this.commitURL = graph.getCommitLink(this);
+        this.authorName = this.author.name;
+        this.authorEmail = this.author.emailAddress;
+        this.commitHashShort = this.displayId;
+    };
+
+    CommitVM.prototype.getAuthorGravatar = function() {
+        return 'http://www.gravatar.com/avatar/' + jQuery.md5(this.author.emailAddress) + '.jpg?s=48'
     };
 
     CommitVM.prototype.getAuthorInitials = function() {
@@ -253,6 +275,13 @@
             return token[0].toUpperCase();
         }).join('');
         return initials.slice(0, 2);
+    };
+
+	CommitVM.prototype.getCommitDate = function() {
+        var d = new Date(this.authorTimestamp);
+        // For further localization
+        var month = ['jan','feb','mar','apr','may','jun','jul','aug','sep','oct','nov','dec'];
+        return d.getDate() + ' ' + month[d.getMonth()] + ' ' + d.getFullYear();
     };
 
     CommitVM.prototype.getAuthorColor = function() {

--- a/src/main/resources/js/commitgraph.js
+++ b/src/main/resources/js/commitgraph.js
@@ -238,17 +238,17 @@
                 $('.commit-container').css('padding-left', width);
 
                 // Create link from issues id
-                if (CommitGraph.useRegex) {
+                if (CommitGraph.useRegex == 'true') {
                     console.log("a");
                     var re = new RegExp(CommitGraph.refRegex, 'g');
 
-                    $(".commits-table .message").each(function () {
+                    $(".commits-table .message > span").each(function () {
                         jQuery(this).html(jQuery(this).text().replace(re, "<a href=\"" + CommitGraph.refRegexReplace + "\" target=\"_blank\">$&</a>"));
                     });
                 }
 
                 // Create link from "http://..." text
-                if (CommitGraph.createLinks) {
+                if (CommitGraph.createLinks == 'true') {
                     $(".commits-table .message").linkify();
                 }
             }

--- a/src/main/resources/js/lib/jquery.linkify.js
+++ b/src/main/resources/js/lib/jquery.linkify.js
@@ -1,0 +1,88 @@
+/*
+ *  Linkify - v1.1.6
+ *  Find URLs in plain text and return HTML for discovered links.
+ *  https://github.com/HitSend/jQuery-linkify/
+ *
+ *  Made by SoapBox Innovations, Inc.
+ *  Under MIT License
+ */
+!function($, window, document) {
+    "use strict";
+    function Linkified(element, options) {
+        this._defaults = defaults, this.element = element, this.setOptions(options), this.init();
+    }
+    var defaults = {
+        tagName: "a",
+        newLine: "\n",
+        target: "_blank",
+        linkClass: null,
+        linkClasses: [],
+        linkAttributes: null
+    };
+    Linkified.prototype = {
+        constructor: Linkified,
+        init: function() {
+            1 === this.element.nodeType ? Linkified.linkifyNode.call(this, this.element) : this.element = Linkified.linkify.call(this, this.element.toString());
+        },
+        setOptions: function(options) {
+            this.settings = Linkified.extendSettings(options, this.settings);
+        },
+        toString: function() {
+            return this.element.toString();
+        }
+    }, Linkified.extendSettings = function(options, settings) {
+        var prop;
+        settings = settings || {};
+        for (prop in defaults) settings[prop] || (settings[prop] = defaults[prop]);
+        for (prop in options) settings[prop] = options[prop];
+        return settings;
+    }, Linkified.linkMatch = new RegExp([ "(", '\\s|[^a-zA-Z0-9.\\+_\\/"\\>\\-]|^', ")(?:", "(", "[a-zA-Z0-9\\+_\\-]+", "(?:", "\\.[a-zA-Z0-9\\+_\\-]+", ")*@", ")?(", "http:\\/\\/|https:\\/\\/|ftp:\\/\\/", ")?(", "(?:(?:[a-z0-9][a-z0-9_%\\-_+]*\\.)+)", ")(", "(?:com|ca|co|edu|gov|net|org|dev|biz|cat|int|pro|tel|mil|aero|asia|coop|info|jobs|mobi|museum|name|post|travel|local|[a-z]{2})", ")(", "(?::\\d{1,5})", ")?(", "(?:", "[\\/|\\?]", "(?:", "[\\-a-zA-Z0-9_%#*&+=~!?,;:.\\/]*", ")*", ")", "[\\-\\/a-zA-Z0-9_%#*&+=~]", "|", "\\/?", ")?", ")(", '[^a-zA-Z0-9\\+_\\/"\\<\\-]|$', ")" ].join(""), "g"), 
+    Linkified.emailLinkMatch = /(<[a-z]+ href=\")(http:\/\/)([a-zA-Z0-9\+_\-]+(?:\.[a-zA-Z0-9\+_\-]+)*@)/g, 
+    Linkified.linkify = function(text, options) {
+        var attr, settings, linkClasses, linkReplace = [];
+        this.constructor === Linkified && this.settings ? (settings = this.settings, options && (settings = Linkified.extendSettings(options, settings))) : settings = Linkified.extendSettings(options), 
+        linkClasses = settings.linkClass ? settings.linkClass.split(/\s+/) : [], linkClasses.push.apply(linkClasses, settings.linkClasses), 
+        text = text.replace(/</g, "&lt;").replace(/(\s)/g, "$1$1"), linkReplace.push("$1<" + settings.tagName, 'href="http://$2$4$5$6$7"'), 
+        linkReplace.push('class="linkified' + (linkClasses.length > 0 ? " " + linkClasses.join(" ") : "") + '"'), 
+        settings.target && linkReplace.push('target="' + settings.target + '"');
+        for (attr in settings.linkAttributes) linkReplace.push([ attr, '="', settings.linkAttributes[attr].replace(/\"/g, "&quot;").replace(/\$/g, "&#36;"), '"' ].join(""));
+        return linkReplace.push(">$2$3$4$5$6$7</" + settings.tagName + ">$8"), text = text.replace(Linkified.linkMatch, linkReplace.join(" ")), 
+        text = text.replace(Linkified.emailLinkMatch, "$1mailto:$3"), text = text.replace(/(\s){2}/g, "$1"), 
+        text = text.replace(/\n/g, settings.newLine);
+    }, Linkified.linkifyNode = function(node) {
+        var children, childNode, childCount, dummyElement, i;
+        if (node && "object" == typeof node && 1 === node.nodeType && "a" !== node.tagName.toLowerCase() && !/[^\s]linkified[\s$]/.test(node.className)) {
+            for (children = [], dummyElement = Linkified._dummyElement || document.createElement("div"), 
+            childNode = node.firstChild, childCount = node.childElementCount; childNode; ) {
+                if (3 === childNode.nodeType) {
+                    for (;dummyElement.firstChild; ) dummyElement.removeChild(dummyElement.firstChild);
+                    for (dummyElement.innerHTML = Linkified.linkify.call(this, childNode.textContent || childNode.innerText || childNode.nodeValue), 
+                    children.push.apply(children, dummyElement.childNodes); dummyElement.firstChild; ) dummyElement.removeChild(dummyElement.firstChild);
+                } else 1 === childNode.nodeType ? children.push(Linkified.linkifyNode(childNode)) : children.push(childNode);
+                childNode = childNode.nextSibling;
+            }
+            for (;node.firstChild; ) node.removeChild(node.firstChild);
+            for (i = 0; i < children.length; i++) node.appendChild(children[i]);
+        }
+        return node;
+    }, Linkified._dummyElement = document.createElement("div"), $.fn.linkify = function(options) {
+        return this.each(function() {
+            var linkified;
+            (linkified = $.data(this, "plugin-linkify")) ? (linkified.setOptions(options), linkified.init()) : $.data(this, "plugin-linkify", new Linkified(this, options));
+        });
+    }, $.fn.linkify.Constructor = Linkified, $(window).on("load", function() {
+        $("[data-linkify]").each(function() {
+            var $target, $this = $(this), target = $this.attr("data-linkify"), options = {
+                tagName: $this.attr("data-linkify-tagname"),
+                newLine: $this.attr("data-linkify-newline"),
+                target: $this.attr("data-linkify-target"),
+                linkClass: $this.attr("data-linkify-linkclass")
+            };
+            for (var option in options) "undefined" == typeof options[option] && delete options[option];
+            $target = "this" === target ? $this : $this.find(target), $target.linkify(options);
+        });
+    }), $("body").on("click", ".linkified", function() {
+        var $link = $(this), url = $link.attr("href"), isEmail = /^mailto:/i.test(url), target = $link.attr("target");
+        return isEmail ? window.location.href = url : window.open(url, target), !1;
+    });
+}(jQuery, window, document);

--- a/src/main/resources/js/lib/jquery.md5.js
+++ b/src/main/resources/js/lib/jquery.md5.js
@@ -1,0 +1,268 @@
+/*
+ * jQuery MD5 Plugin 1.2.1
+ * https://github.com/blueimp/jQuery-MD5
+ *
+ * Copyright 2010, Sebastian Tschan
+ * https://blueimp.net
+ *
+ * Licensed under the MIT license:
+ * http://creativecommons.org/licenses/MIT/
+ * 
+ * Based on
+ * A JavaScript implementation of the RSA Data Security, Inc. MD5 Message
+ * Digest Algorithm, as defined in RFC 1321.
+ * Version 2.2 Copyright (C) Paul Johnston 1999 - 2009
+ * Other contributors: Greg Holt, Andrew Kepert, Ydnar, Lostinet
+ * Distributed under the BSD License
+ * See http://pajhome.org.uk/crypt/md5 for more info.
+ */
+
+/*jslint bitwise: true */
+/*global unescape, jQuery */
+;(function ($) {
+    'use strict';
+
+    /*
+    * Add integers, wrapping at 2^32. This uses 16-bit operations internally
+    * to work around bugs in some JS interpreters.
+    */
+    function safe_add(x, y) {
+        var lsw = (x & 0xFFFF) + (y & 0xFFFF),
+            msw = (x >> 16) + (y >> 16) + (lsw >> 16);
+        return (msw << 16) | (lsw & 0xFFFF);
+    }
+
+    /*
+    * Bitwise rotate a 32-bit number to the left.
+    */
+    function bit_rol(num, cnt) {
+        return (num << cnt) | (num >>> (32 - cnt));
+    }
+
+    /*
+    * These functions implement the four basic operations the algorithm uses.
+    */
+    function md5_cmn(q, a, b, x, s, t) {
+        return safe_add(bit_rol(safe_add(safe_add(a, q), safe_add(x, t)), s), b);
+    }
+    function md5_ff(a, b, c, d, x, s, t) {
+        return md5_cmn((b & c) | ((~b) & d), a, b, x, s, t);
+    }
+    function md5_gg(a, b, c, d, x, s, t) {
+        return md5_cmn((b & d) | (c & (~d)), a, b, x, s, t);
+    }
+    function md5_hh(a, b, c, d, x, s, t) {
+        return md5_cmn(b ^ c ^ d, a, b, x, s, t);
+    }
+    function md5_ii(a, b, c, d, x, s, t) {
+        return md5_cmn(c ^ (b | (~d)), a, b, x, s, t);
+    }
+
+    /*
+    * Calculate the MD5 of an array of little-endian words, and a bit length.
+    */
+    function binl_md5(x, len) {
+        /* append padding */
+        x[len >> 5] |= 0x80 << ((len) % 32);
+        x[(((len + 64) >>> 9) << 4) + 14] = len;
+
+        var i, olda, oldb, oldc, oldd,
+            a =  1732584193,
+            b = -271733879,
+            c = -1732584194,
+            d =  271733878;
+
+        for (i = 0; i < x.length; i += 16) {
+            olda = a;
+            oldb = b;
+            oldc = c;
+            oldd = d;
+
+            a = md5_ff(a, b, c, d, x[i],       7, -680876936);
+            d = md5_ff(d, a, b, c, x[i +  1], 12, -389564586);
+            c = md5_ff(c, d, a, b, x[i +  2], 17,  606105819);
+            b = md5_ff(b, c, d, a, x[i +  3], 22, -1044525330);
+            a = md5_ff(a, b, c, d, x[i +  4],  7, -176418897);
+            d = md5_ff(d, a, b, c, x[i +  5], 12,  1200080426);
+            c = md5_ff(c, d, a, b, x[i +  6], 17, -1473231341);
+            b = md5_ff(b, c, d, a, x[i +  7], 22, -45705983);
+            a = md5_ff(a, b, c, d, x[i +  8],  7,  1770035416);
+            d = md5_ff(d, a, b, c, x[i +  9], 12, -1958414417);
+            c = md5_ff(c, d, a, b, x[i + 10], 17, -42063);
+            b = md5_ff(b, c, d, a, x[i + 11], 22, -1990404162);
+            a = md5_ff(a, b, c, d, x[i + 12],  7,  1804603682);
+            d = md5_ff(d, a, b, c, x[i + 13], 12, -40341101);
+            c = md5_ff(c, d, a, b, x[i + 14], 17, -1502002290);
+            b = md5_ff(b, c, d, a, x[i + 15], 22,  1236535329);
+
+            a = md5_gg(a, b, c, d, x[i +  1],  5, -165796510);
+            d = md5_gg(d, a, b, c, x[i +  6],  9, -1069501632);
+            c = md5_gg(c, d, a, b, x[i + 11], 14,  643717713);
+            b = md5_gg(b, c, d, a, x[i],      20, -373897302);
+            a = md5_gg(a, b, c, d, x[i +  5],  5, -701558691);
+            d = md5_gg(d, a, b, c, x[i + 10],  9,  38016083);
+            c = md5_gg(c, d, a, b, x[i + 15], 14, -660478335);
+            b = md5_gg(b, c, d, a, x[i +  4], 20, -405537848);
+            a = md5_gg(a, b, c, d, x[i +  9],  5,  568446438);
+            d = md5_gg(d, a, b, c, x[i + 14],  9, -1019803690);
+            c = md5_gg(c, d, a, b, x[i +  3], 14, -187363961);
+            b = md5_gg(b, c, d, a, x[i +  8], 20,  1163531501);
+            a = md5_gg(a, b, c, d, x[i + 13],  5, -1444681467);
+            d = md5_gg(d, a, b, c, x[i +  2],  9, -51403784);
+            c = md5_gg(c, d, a, b, x[i +  7], 14,  1735328473);
+            b = md5_gg(b, c, d, a, x[i + 12], 20, -1926607734);
+
+            a = md5_hh(a, b, c, d, x[i +  5],  4, -378558);
+            d = md5_hh(d, a, b, c, x[i +  8], 11, -2022574463);
+            c = md5_hh(c, d, a, b, x[i + 11], 16,  1839030562);
+            b = md5_hh(b, c, d, a, x[i + 14], 23, -35309556);
+            a = md5_hh(a, b, c, d, x[i +  1],  4, -1530992060);
+            d = md5_hh(d, a, b, c, x[i +  4], 11,  1272893353);
+            c = md5_hh(c, d, a, b, x[i +  7], 16, -155497632);
+            b = md5_hh(b, c, d, a, x[i + 10], 23, -1094730640);
+            a = md5_hh(a, b, c, d, x[i + 13],  4,  681279174);
+            d = md5_hh(d, a, b, c, x[i],      11, -358537222);
+            c = md5_hh(c, d, a, b, x[i +  3], 16, -722521979);
+            b = md5_hh(b, c, d, a, x[i +  6], 23,  76029189);
+            a = md5_hh(a, b, c, d, x[i +  9],  4, -640364487);
+            d = md5_hh(d, a, b, c, x[i + 12], 11, -421815835);
+            c = md5_hh(c, d, a, b, x[i + 15], 16,  530742520);
+            b = md5_hh(b, c, d, a, x[i +  2], 23, -995338651);
+
+            a = md5_ii(a, b, c, d, x[i],       6, -198630844);
+            d = md5_ii(d, a, b, c, x[i +  7], 10,  1126891415);
+            c = md5_ii(c, d, a, b, x[i + 14], 15, -1416354905);
+            b = md5_ii(b, c, d, a, x[i +  5], 21, -57434055);
+            a = md5_ii(a, b, c, d, x[i + 12],  6,  1700485571);
+            d = md5_ii(d, a, b, c, x[i +  3], 10, -1894986606);
+            c = md5_ii(c, d, a, b, x[i + 10], 15, -1051523);
+            b = md5_ii(b, c, d, a, x[i +  1], 21, -2054922799);
+            a = md5_ii(a, b, c, d, x[i +  8],  6,  1873313359);
+            d = md5_ii(d, a, b, c, x[i + 15], 10, -30611744);
+            c = md5_ii(c, d, a, b, x[i +  6], 15, -1560198380);
+            b = md5_ii(b, c, d, a, x[i + 13], 21,  1309151649);
+            a = md5_ii(a, b, c, d, x[i +  4],  6, -145523070);
+            d = md5_ii(d, a, b, c, x[i + 11], 10, -1120210379);
+            c = md5_ii(c, d, a, b, x[i +  2], 15,  718787259);
+            b = md5_ii(b, c, d, a, x[i +  9], 21, -343485551);
+
+            a = safe_add(a, olda);
+            b = safe_add(b, oldb);
+            c = safe_add(c, oldc);
+            d = safe_add(d, oldd);
+        }
+        return [a, b, c, d];
+    }
+
+    /*
+    * Convert an array of little-endian words to a string
+    */
+    function binl2rstr(input) {
+        var i,
+            output = '';
+        for (i = 0; i < input.length * 32; i += 8) {
+            output += String.fromCharCode((input[i >> 5] >>> (i % 32)) & 0xFF);
+        }
+        return output;
+    }
+
+    /*
+    * Convert a raw string to an array of little-endian words
+    * Characters >255 have their high-byte silently ignored.
+    */
+    function rstr2binl(input) {
+        var i,
+            output = [];
+        output[(input.length >> 2) - 1] = undefined;
+        for (i = 0; i < output.length; i += 1) {
+            output[i] = 0;
+        }
+        for (i = 0; i < input.length * 8; i += 8) {
+            output[i >> 5] |= (input.charCodeAt(i / 8) & 0xFF) << (i % 32);
+        }
+        return output;
+    }
+
+    /*
+    * Calculate the MD5 of a raw string
+    */
+    function rstr_md5(s) {
+        return binl2rstr(binl_md5(rstr2binl(s), s.length * 8));
+    }
+
+    /*
+    * Calculate the HMAC-MD5, of a key and some data (raw strings)
+    */
+    function rstr_hmac_md5(key, data) {
+        var i,
+            bkey = rstr2binl(key),
+            ipad = [],
+            opad = [],
+            hash;
+        ipad[15] = opad[15] = undefined;                        
+        if (bkey.length > 16) {
+            bkey = binl_md5(bkey, key.length * 8);
+        }
+        for (i = 0; i < 16; i += 1) {
+            ipad[i] = bkey[i] ^ 0x36363636;
+            opad[i] = bkey[i] ^ 0x5C5C5C5C;
+        }
+        hash = binl_md5(ipad.concat(rstr2binl(data)), 512 + data.length * 8);
+        return binl2rstr(binl_md5(opad.concat(hash), 512 + 128));
+    }
+
+    /*
+    * Convert a raw string to a hex string
+    */
+    function rstr2hex(input) {
+        var hex_tab = '0123456789abcdef',
+            output = '',
+            x,
+            i;
+        for (i = 0; i < input.length; i += 1) {
+            x = input.charCodeAt(i);
+            output += hex_tab.charAt((x >>> 4) & 0x0F) +
+                hex_tab.charAt(x & 0x0F);
+        }
+        return output;
+    }
+
+    /*
+    * Encode a string as utf-8
+    */
+    function str2rstr_utf8(input) {
+        return unescape(encodeURIComponent(input));
+    }
+
+    /*
+    * Take string arguments and return either raw or hex encoded strings
+    */
+    function raw_md5(s) {
+        return rstr_md5(str2rstr_utf8(s));
+    }
+    function hex_md5(s) {
+        return rstr2hex(raw_md5(s));
+    }
+    function raw_hmac_md5(k, d) {
+        return rstr_hmac_md5(str2rstr_utf8(k), str2rstr_utf8(d));
+    }
+    function hex_hmac_md5(k, d) {
+        return rstr2hex(raw_hmac_md5(k, d));
+    }
+    
+    $.md5 = function (string, key, raw) {
+        if (!key) {
+            if (!raw) {
+                return hex_md5(string);
+            } else {
+                return raw_md5(string);
+            }
+        }
+        if (!raw) {
+            return hex_hmac_md5(key, string);
+        } else {
+            return raw_hmac_md5(key, string);
+        }
+    };
+    
+}(typeof jQuery === 'function' ? jQuery : this));

--- a/src/main/resources/templates/network.soy
+++ b/src/main/resources/templates/network.soy
@@ -2,6 +2,7 @@
 
 /**
  * @param repository Repository object
+ * @param settings
  */
 {template .network}
 <html>
@@ -16,7 +17,12 @@
     <script>
         var CommitGraph = {lb}
             projectKey: '{$repository.project.key}',
-            repoSlug: '{$repository.slug}'
+            repoSlug: '{$repository.slug}',
+            refRegex: '{$settings.refRegex}',
+            refRegexReplace: '{$settings.refRegexReplace}',
+            useRegex: '{$settings.useRegex}',
+            useGravatar: '{$settings.useGravatar}',
+            createLinks: '{$settings.createLinks}'
         {rb};
     </script>
     <div class="commit-graph-loader" data-bind="visible: isLoading()">
@@ -30,18 +36,42 @@
                 <table class="aui paged-table commits-table" id="commit-graph-table" data-start="0">
                     <thead>
                         <tr>
-                            <th>Message</th>
+                            <th class="author"></th>
+                            <th class="changeset">Commit</th>
+                            <th class="message">Message</th>
                             <th class="commit-date">Commit Date</th>
                         </tr>
                     </thead>
+
                     {literal}
                     <tbody data-bind="foreach: displayCommits">
                         <tr data-bind="attr: { class: 'commit-row' + (isMerge ? ' merge' : '') }">
-                            <td class="commit-message">
-                                <span data-bind="text: getAuthorInitials(), attr: { style: 'background-color: ' + getAuthorColor() }" class="commiter-initials"></span>
-                                <a data-bind="text: message, attr: { href: commitURL }" target="_blank"></a>
+                            <td class="author">
+                                <div class="avatar-without-name" data-bind="attr: {title: authorName }">
+                                    <span class="aui-avatar aui-avatar-small user-avatar">
+                                        <span class="aui-avatar-inner">
+                                        {/literal}
+                                        {if $settings.useGravatar}
+                                        {literal}
+                                            <img data-bind="attr: {src: getAuthorGravatar(), alt: authorName }">
+                                        {/literal}
+                                        {else}
+                                        {literal}
+                                            <span data-bind="text: getAuthorInitials(), attr: { style: 'background-color: ' + getAuthorColor() }" class="commiter-initials"></span>
+                                        {/literal}
+                                        {/if}
+                                        {literal}
+                                        </span>
+                                    </span>
+                                </div>
                             </td>
-                            <td class="commit-date" data-bind="text: date.toDateString()"></td>
+                            <td class="changeset">
+                                <a class="changesetid" data-bind="text: commitHashShort, attr: { href: commitURL }"></a>
+                            </td>
+                            <td class="message">
+                                <span data-bind="text: message"></span>
+                            </td>
+                            <td class="commit-date" data-bind="text: getCommitDate()"></td>
                         </tr>
                     </tbody>
                     {/literal}

--- a/src/main/resources/templates/repositorySettingsPage.soy
+++ b/src/main/resources/templates/repositorySettingsPage.soy
@@ -1,0 +1,139 @@
+{namespace plugin.commitgraph}
+
+/**
+ * Repository settings page template
+ * @param repository
+ * @param settings
+ * @param errors
+ */
+{template .repositorySettingsPage}
+
+<html>
+<meta name="decorator" content="stash.repository.settings">
+<meta name="projectKey" content="{$repository.project.key}">
+<meta name="repositorySlug" content="{$repository.slug}">
+<meta name="activeTab" content="repository-settings-git-ops-panel">
+<head>
+    <title>Stash Network Repository Settings</title>
+</head>
+<body>
+<style>
+    {literal}
+    .aui-group.wrap {
+        border-top: 1px solid #cccccc;
+        padding: 5px 0;
+    }
+    .aui-group.wrap .aui-group-description {
+        margin-top: 10px;
+        margin-bottom: 10px;
+    }
+    form.aui .buttons-container {
+        border-top: 1px solid #cccccc;
+        padding-top: 10px;
+    }
+    {/literal}
+</style>
+{call aui.group.group}
+    {param content}
+        {call aui.group.item}
+            {param content}
+                <h2>Network Repository Settings</h2>
+            {/param}
+        {/call}
+    {/param}
+{/call}
+
+{if $errors.0}
+    {call widget.aui.message.error}
+        {param content}
+            <ul>
+            {foreach $error in $errors}
+                <li>{$error}</li>
+            {/foreach}
+            </ul>
+        {/param}
+    {/call}
+{/if}
+
+{call aui.group.group} {param content} {call aui.form.form}
+    {param action: '' /}
+    {param content}
+        {call aui.form.checkboxField}
+            {param legendContent: '' /}
+            {param fields: [[
+                'id': 'useGravatar',
+                'labelText': 'Use gravatar service to show commit author avatar',
+                'isChecked': $settings.useGravatar
+                ]] /}
+        {/call}
+        {call aui.form.checkboxField}
+            {param legendContent: '' /}
+            {param fields: [[
+                'id': 'createLinks',
+                'labelText': 'Create links from "http://..." text in commit messages',
+                'isChecked': $settings.createLinks
+                ]] /}
+        {/call}
+
+        {call aui.group.group}
+            {param extraClasses: 'wrap' /}
+            {param content}
+                <div class="aui-group-description">
+                    <h3>Link from issue ID</h3>
+                    <p>Allows to use regex to match issue id in commit message and create link from it.</p>
+                </div>
+                {call aui.form.checkboxField}
+                    {param legendContent: '' /}
+                    {param fields: [[
+                        'id': 'useRegex',
+                        'labelText': 'Enable',
+                        'isChecked': $settings.useRegex
+                        ]] /}
+                {/call}
+                {call aui.form.textField}
+                    {param id: 'refRegex' /}
+                    {param labelContent: 'Regex to match issue id' /}
+                    {param value: $settings.refRegex /}
+                    {param descriptionText: 'Regular expression to match issue id. Note that special characters must be preceded with extra \\. Default value is "\\\\B#(\\\\d+)".' /}
+                {/call}
+                {call aui.form.textField}
+                    {param id: 'refRegexReplace' /}
+                    {param labelContent: 'Link href' /}
+                    {param value: $settings.refRegexReplace /}
+                    {param descriptionText: 'Regex matches will be replaced by <a> tag with "href" attribute filled from this replace pattern. Use $1, $2, ...  to insert group matches.' /}
+                {/call}
+            {/param}
+        {/call}
+
+        {call aui.form.buttons}
+            {param content}
+                {call aui.form.submit}
+                    {param id: 'saveButton' /}
+                    {param text: 'Save' /}
+                    {param type: 'submit' /}
+                    {param extraClasses: 'aui-button aui-button-primary' /}
+                {/call}
+            {/param}
+        {/call}
+    {/param}
+{/call} {/param} {/call}
+
+{literal}<script>
+AJS.$("form").submit(function() {
+    AJS.$("input").removeAttr("disabled");
+    AJS.$("input").addAttr("readonly");
+});
+
+function updateRegexState(checked) {
+    AJS.$("#refRegex").prop("disabled", !checked);
+    AJS.$("#refRegexReplace").prop("disabled", !checked);
+}
+AJS.$("#useRegex").change(function() {
+    updateRegexState(this.checked);
+});
+updateRegexState(AJS.$("#useRegex").prop('checked'));
+
+</script>{/literal}
+</body>
+</html>
+{/template}

--- a/src/test/java/it/com/plugin/commitgraph/admin/RepositorySettingsServletFuncTest.java
+++ b/src/test/java/it/com/plugin/commitgraph/admin/RepositorySettingsServletFuncTest.java
@@ -1,0 +1,44 @@
+package it.com.plugin.commitgraph.admin;
+
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.BasicResponseHandler;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.junit.Test;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+
+public class RepositorySettingsServletFuncTest {
+
+    HttpClient httpClient;
+    String baseUrl;
+    String servletUrl;
+
+    @Before
+    public void setup() {
+        httpClient = new DefaultHttpClient();
+        baseUrl = System.getProperty("baseurl");
+        servletUrl = baseUrl + "/plugins/servlet/repositorysettingsservlet";
+    }
+
+    @After
+    public void tearDown() {
+        httpClient.getConnectionManager().shutdown();
+    }
+
+    @Test
+    public void testSomething() throws IOException {
+        HttpGet httpget = new HttpGet(servletUrl);
+
+        // Create a response handler
+        ResponseHandler<String> responseHandler = new BasicResponseHandler();
+        String responseBody = httpClient.execute(httpget, responseHandler);
+        assertTrue(null != responseBody && !"".equals(responseBody));
+    }
+}

--- a/src/test/java/ut/com/plugin/commitgraph/admin/RepositorySettingsServletTest.java
+++ b/src/test/java/ut/com/plugin/commitgraph/admin/RepositorySettingsServletTest.java
@@ -1,0 +1,37 @@
+package ut.com.plugin.commitgraph.admin;
+
+import org.junit.Test;
+import org.junit.After;
+import org.junit.Before;
+import org.mockito.Mockito;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class RepositorySettingsServletTest {
+
+    HttpServletRequest mockRequest;
+    HttpServletResponse mockResponse;
+
+    @Before
+    public void setup() {
+        mockRequest = mock(HttpServletRequest.class);
+        mockResponse = mock(HttpServletResponse.class);
+    }
+
+    @After
+    public void tearDown() {
+
+    }
+
+    @Test
+    public void testSomething() {
+        String expected = "test";
+        when(mockRequest.getParameter(Mockito.anyString())).thenReturn(expected);
+        assertEquals(expected,mockRequest.getParameter("some string"));
+
+    }
+}


### PR DESCRIPTION
Hi, cha55son. First of all I want to thank you for plugin! It was the first one that I've immediately install to Stash. 

But some feature I was missing:
- Gravatar
- URL in commit messages was just text
- Links to issues

So I've made repository setting page to manage this options.

![network-plugin-settings](https://cloud.githubusercontent.com/assets/5602016/5888476/cb8a631a-a410-11e4-9ebc-ba0af811492c.PNG)

First checkbox enables Gravatar support.

Second creates links from URLs. E.g. if commit message is `Super feature is done. See www.somedocs.com/somepage` than `www.somedocs.com/somepage` is replaced by link, so user can easy follow it.

Next options group is for create links from various issue ids. 
User need to specify regex to match issue id and how to transform it to link. E.g. default match regex value is `\\B#(\\d+)` and replace value is `http://some.website/issue/$1`. So it will match `#1234` from commit message `Issue #1234 was resolved` and create link to `http://some.website/issue/1234`.

Next screenshot shows main plugin page when settings from previous one was specified.

![network-plugin-mainpage](https://cloud.githubusercontent.com/assets/5602016/5888515/965671aa-a412-11e4-9c5e-98abc29fb1f5.PNG)

And yes, main page UI was modified to looks like original stash `Commits` page.

![commits-mainpage](https://cloud.githubusercontent.com/assets/5602016/5888531/7d3e1a8c-a413-11e4-981b-9cf81039af68.PNG)

I hope that my ideas and code can be useful to you :wink: