### PR TITLE
issue #56: fix huge grey labels

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.plugin.commitgraph</groupId>
     <artifactId>commitgraph</artifactId>
-    <version>2.0</version>
+    <version>2.1</version>
 
     <organization>
         <name>Chason Choate</name>

--- a/src/main/resources/static/js/lib/jquery.commitgraph.js
+++ b/src/main/resources/static/js/lib/jquery.commitgraph.js
@@ -150,6 +150,17 @@
             }
             var textBBox = labels.getBBox();
             var textPadding = 3, LRPadding = 3;
+
+            // issue #56: Display issue - huge grey box on Commit Graph
+            // modded by tirolerstefan (using hint of darkdams, thanks)
+            // https://github.com/cha55son/stash-commit-graph-plugin/issues/56#issuecomment-171966535
+            textBBox.height=14;
+            textBBox.x=0;
+            textBBox.y=-7;
+            textBBox.x2=startX;
+            textBBox.y2=7;
+            textBBox.width=startX;
+
             // Draw the label box
             var labelBox = this.paper
                 .rect(triXPos - textBBox.width - textPadding * 2 - LRPadding * 2,


### PR DESCRIPTION
This is a possible fix/workaround for grey ref labels with incorrect size calculation, see issue #56 .
Fix was proposed by @darkdams in his comment.