### PR TITLE
[issue #59] Distinguish branch and tag names

### DIFF
--- a/src/main/resources/static/js/lib/jquery.commitgraph.js
+++ b/src/main/resources/static/js/lib/jquery.commitgraph.js
@@ -133,13 +133,16 @@
             ]).attr({ fill: color, stroke: 'none' });
             var textAttrs = { fill: '#FFF', font: '11px monospace', 'text-anchor': 'start' };
             var labelAttrs = $.extend({ cursor: 'pointer' }, textAttrs);
+            var tagAttrs = $.extend({}, labelAttrs, { 'font-style': 'italic', fill: '#FFB' });
+            var branchAttrs = $.extend({}, labelAttrs, { fill: '#BFB' });
             // Create the labels and link to their respective pages
             var labels = this.paper.set();
             var startX = 0;
             for (var i = 0; i < point.labels.length; i++) {
-                var text = this.paper.text(startX, 0, point.labels[i].name).attr(labelAttrs);
+                var label = point.labels[i];
+                var text = this.paper.text(startX, 0, label.name).attr(label.type == 'TAG' ? tagAttrs : branchAttrs);
                 startX += text.getBBox().width;
-                text._label = point.labels[i];
+                text._label = label;
                 text.click(function() { window.open(this._label.href); });
                 labels.push(text);
                 if (i < point.labels.length - 1) {

--- a/src/main/resources/static/network.soy
+++ b/src/main/resources/static/network.soy
@@ -126,6 +126,7 @@
                                         {foreach $label in $labels[$commit.id]}
                                             {lb}
                                                 name: '{$label.displayId|escapeJs}',
+                                                type: '{$label.type}',
                                                 href: '{nav_repo_browse($repository.project.key, $repository.slug)}?at={$label.displayId|escapeJs}'
                                             {rb}
                                             {if isLast($label) == false},{/if}

--- a/src/main/resources/static/network.soy
+++ b/src/main/resources/static/network.soy
@@ -125,8 +125,8 @@
                                     labels: [
                                         {foreach $label in $labels[$commit.id]}
                                             {lb}
-                                                name: '{$label.displayId}',
-                                                href: '{nav_repo_browse($repository.project.key, $repository.slug)}?at={$label.displayId}'
+                                                name: '{$label.displayId|escapeJs}',
+                                                href: '{nav_repo_browse($repository.project.key, $repository.slug)}?at={$label.displayId|escapeJs}'
                                             {rb}
                                             {if isLast($label) == false},{/if}
                                         {/foreach}


### PR DESCRIPTION
Bitbucket doesn't deal correctly with branches containing quotes in names (you cannot create one using ui, for instance), but nothing stops users to push such branches.
Commit graph currently fails to render completely when such label exists in the graph. This PR fixes that.