### PR TITLE
Change topo-order to date-order

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.plugin.commitgraph</groupId>
     <artifactId>commitgraph</artifactId>
-    <version>2.1</version>
+    <version>2.2</version>
 
     <organization>
         <name>Chason Choate</name>

--- a/src/main/java/networkservlet/NetworkServlet.java
+++ b/src/main/java/networkservlet/NetworkServlet.java
@@ -150,7 +150,7 @@ public class NetworkServlet extends HttpServlet {
         revList.argumentAt(0, "--pretty=" + FORMAT );
         revList.argumentAt(1, "--branches=*" );
         revList.argumentAt(2, "--tags=*" );
-        revList.argumentAt(3, "--topo-order" );
+        revList.argumentAt(3, "--date-order" );
         GitCommand<Page<Commit>> revListCmd = revList.build(pcoh);
         Page<Commit> commits = revListCmd.synchronous().call();
         if ( commits == null ) {


### PR DESCRIPTION
Change to date-order because topo-order doesn´t work very well at repos with a lot of tags. Fixing also #69 